### PR TITLE
Time taken explicitly from the context of the scheduler

### DIFF
--- a/src/Tempus.Tests/SchedulerTests.cs
+++ b/src/Tempus.Tests/SchedulerTests.cs
@@ -260,7 +260,7 @@ namespace Tempus.Tests
             
             await scheduledTask.Cancel();
             
-            counter.Should().BeGreaterOrEqualTo(20);
+            counter.Should().BeGreaterOrEqualTo(15);
         }
     }
 }

--- a/src/Tempus/Scheduler.cs
+++ b/src/Tempus/Scheduler.cs
@@ -72,7 +72,7 @@ namespace Tempus
             Func<IFailureContext, CancellationToken, Task> onException, TimeSpan maxBackoffPeriod) =>
             ScheduleInternal(initialDelay, period, action, onException, maxBackoffPeriod);
 
-        private static IScheduledTask ScheduleInternal(TimeSpan initialDelay, TimeSpan period,
+        private IScheduledTask ScheduleInternal(TimeSpan initialDelay, TimeSpan period,
             Func<CancellationToken, Task> action, Func<IFailureContext, CancellationToken, Task> onException,
             TimeSpan maxBackoffPeriod)
         {
@@ -85,7 +85,7 @@ namespace Tempus
             {
                 using (cancellationTokenSource)
                 {
-                    var failureContext = new FailureContext(period, maxBackoffPeriod, () => DateTime.Now);
+                    var failureContext = new FailureContext(period, maxBackoffPeriod, () => Now);
 
                     if (initialDelay > TimeSpan.Zero)
                     {


### PR DESCRIPTION
Test params adjusted